### PR TITLE
ci: add check for number of zone files

### DIFF
--- a/.github/workflows/update-serial.yml
+++ b/.github/workflows/update-serial.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - name: "Check-out"
         uses: actions/checkout@v3
+      - name: "Pre-Check"
+        run: |
+          num_zonefiles="$(ls  ${{ env.ZONE_FILE }} | wc -l)
+          if [ "$num_zonefiles" != 1 ];
+          then
+            echo "Incorrect number of Zone files. Expected 1, got $num_zonefiles"
+            exit 1
+          fi
       - name: "Update DNS Zone Serial"
         id: generate-serial
         run: |


### PR DESCRIPTION
ci should fail if there are no more than 1 zone files
closes #1 